### PR TITLE
[CHANGE] Disable core update emails only on successful updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Section Order:
 ### Changed
 
 - Put constants under our namespace to avoid potential conflicts
+- Disable core update emails only on successful updates, failed core updates will still send emails
 
 ## \[1.1.0\] - 2024-05-07
 

--- a/Sources/Tweaks/AutoUpdateMails.php
+++ b/Sources/Tweaks/AutoUpdateMails.php
@@ -31,7 +31,8 @@ class AutoUpdateMails implements TweaksInterface {
                 object $coreUpdate,
                 object $result
             ): bool {
-                return false;
+                // Disable core update emails only on successful updates.
+                return !(!empty($type) && $type === 'success');
             },
         );
         add_filter(
@@ -41,6 +42,7 @@ class AutoUpdateMails implements TweaksInterface {
                 object $plugin,
                 object $result
             ): bool {
+                // Disable plugin update emails.
                 return false;
             }
         );
@@ -51,6 +53,7 @@ class AutoUpdateMails implements TweaksInterface {
                 object $theme,
                 object $result
             ): bool {
+                // Disable theme update emails.
                 return false;
             }
         );


### PR DESCRIPTION
## Description

### Changed

- Disable core update emails only on successful updates, failed core updates will still send emails

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
