### PR TITLE
[FIX] Move `load_plugin_textdomain` to the right hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Section Order:
 ### Security
 -->
 
+### Fixed
+
+- Move `load_plugin_textdomain` to the right hook
+
 ### [1.3.1] - 2024-10-16
 
 #### Changed

--- a/Sources/Main.php
+++ b/Sources/Main.php
@@ -32,11 +32,7 @@ class Main {
      * @return void
      */
     public function __construct() {
-        /**
-         * Initializing Variables
-         */
-        $this->textDomain = 'pp-wordpress-tweaks';
-        $this->localizationDirectory = basename(path: __DIR__) . '/l10n/';
+        $this->init();
     }
 
     /**
@@ -50,25 +46,9 @@ class Main {
      * @uses doUpdateCheck()
      */
     public function init(): void {
-        $this->loadTextDomain();
         $this->loadSettings();
         $this->loadTweaks();
         $this->doUpdateCheck();
-    }
-
-    /**
-     * Load the text domain
-     *
-     * @return void
-     * @since 1.0.0
-     * @access public
-     * @uses load_plugin_textdomain()
-     */
-    public function loadTextDomain(): void {
-        load_plugin_textdomain(
-            domain: $this->textDomain,
-            plugin_rel_path: $this->localizationDirectory
-        );
     }
 
     /**

--- a/WordPressTweaks.php
+++ b/WordPressTweaks.php
@@ -45,5 +45,14 @@ require_once trailingslashit(value: __DIR__) . 'Sources/autoloader.php';
 require_once trailingslashit(value: __DIR__) . 'Sources/Libs/autoload.php';
 // phpcs:enable
 
+// Load the text domain.
+add_action(hook_name: 'init', callback: static function () {
+    load_plugin_textdomain(
+        domain: 'pp-wordpress-tweaks',
+        deprecated: false,
+        plugin_rel_path: basename(path: __DIR__) . '/l10n/'
+    );
+});
+
 // Load the plugin's main class.
-(new Main())->init();
+new Main();


### PR DESCRIPTION
## Description

### Fixed

- Move `load_plugin_textdomain` to the right hook

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
