### PR TITLE
[CHANGE] Use `__NAMESPACE__` instead of hardcoded namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Section Order:
 ### Security
 -->
 
+### Changed
+
+- Use `__NAMESPACE__` instead of hardcoded namespace when appropriate
+
 ### [1.5.0] - 2024-12-27
 
 ### Fixed

--- a/Sources/Tweaks.php
+++ b/Sources/Tweaks.php
@@ -19,7 +19,7 @@ class Tweaks extends GenericSingleton {
     public function getTweakClasses(): array {
         return array_filter(
             array_map(
-                static fn($file) => '\\Ppfeufer\\Plugin\\WordPressTweaks\\Tweaks\\' . basename(path: $file, suffix: '.php'),
+                static fn($file) => '\\' . __NAMESPACE__ . '\\Tweaks\\' . basename(path: $file, suffix: '.php'),
                 glob(pattern: PLUGIN_DIR_PATH . '/Sources/Tweaks/*.php')
             ),
             static fn($class) => class_exists(class: $class)

--- a/Sources/autoload.php
+++ b/Sources/autoload.php
@@ -7,7 +7,7 @@ use RuntimeException;
 
 // Register the autoloader.
 // phpcs:disable
-spl_autoload_register(callback: '\Ppfeufer\Plugin\WordPressTweaks\autoload');
+spl_autoload_register(callback: '\\' . __NAMESPACE__ . '\autoload');
 // phpcs:enable
 
 /**


### PR DESCRIPTION
## Description

### Changed

- Use `__NAMESPACE__` instead of hardcoded namespace when appropriate

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
