### PR TITLE
[FIX] Missing callback function in Emoji tweak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Section Order:
 ### Security
 -->
 
+### Fixed
+
+- Fatal error: Uncaught TypeError: call_user_func_array(): Argument #1 ($callback) must be a valid callback, class Ppfeufer\\Plugin\\WordPressTweaks\\Tweaks\\Emoji does not have a method "disableTinymceEmojicons"
+
 ### Changed
 
 - Use `__NAMESPACE__` instead of hardcoded namespace when appropriate

--- a/Sources/Tweaks/Emoji.php
+++ b/Sources/Tweaks/Emoji.php
@@ -71,6 +71,17 @@ class Emoji extends GenericSingleton implements TweakInterface {
     }
 
     /**
+     * Disable the tinymce emojicons
+     *
+     * @param array $plugins The plugins
+     * @return array
+     * @access public
+     */
+    public function disableTinymceEmojicons(array $plugins): array {
+        return array_diff($plugins, ['wpemoji']);
+    }
+
+    /**
      * Execute the filters and so on
      *
      * @return void


### PR DESCRIPTION
## Description

### Fixed

- Fatal error: Uncaught TypeError: call_user_func_array(): Argument # 1 ($callback) must be a valid callback, class Ppfeufer\\Plugin\\WordPressTweaks\\Tweaks\\Emoji does not have a method "disableTinymceEmojicons"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
